### PR TITLE
Cleans up some variables and matches spec more closely

### DIFF
--- a/lib/enigma.rb
+++ b/lib/enigma.rb
@@ -5,17 +5,19 @@ require './lib/decrypter'
 class Enigma
 
   def initialize
+    @date_string = Date.today.strftime("%d%m%y")
   end
 
-  def encrypt(message, key = [*"00001".."99999"].sample, date = Date.today)
+  def encrypt(message, key = [*"00001".."99999"].sample, date = @date_string)
     encrypter = Encrypter.new(message, key, date)
     new_text = encrypter.letter_encryption(message.downcase.chomp)
     {encryption: new_text, key: key, date: date}
   end
 
-  def decrypt(encryption, key, date = Date.today)
+  def decrypt(encryption, key, date = @date_string)
     decrypter = Decrypter.new(encryption, key, date)
-    new_text = decrypter.letter_decryption(encryption.downcase.chomp)
+    new_text = decrypter.letter_decryption(encryption.downcase.chomp) if encryption.class == String
+    new_text = decrypter.letter_decryption(encryption[:encryption].downcase.chomp) if encryption.class == Hash
     {decryption: new_text, key: key, date: date}
   end
 


### PR DESCRIPTION
The interaction pattern in the spec has this evil part in it:
encrypted = enigma.encrypt("hello world", "02715")
enigma.decrypt(encrypted, "02715")

this means that the variable `encrypted` is a hash, and therefore the decrypt method needs to account for two different data types. added this functionality.